### PR TITLE
fix: Registry dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,10 +95,10 @@
     "react-intl": "^5.8.1",
     "react-query": "^3.9.0",
     "react-router-dom": "^5.2.0",
-    "sinon": "^9.0.2"
+    "sinon": "^9.0.2",
+    "@folio/handler-stripes-registry": "^1.0.0"
   },
   "dependencies": {
-    "@folio/handler-stripes-registry": "^1.0.0",
     "@k-int/stripes-kint-components": "^2.0.0",
     "@folio/react-intl-safe-html": "^3.1.0",
     "@folio/stripes-erm-components": "^6.0.0",
@@ -114,6 +114,7 @@
     "react-xarrows": "1.7.0"
   },
   "peerDependencies": {
+    "@folio/handler-stripes-registry": "^1.0.0",
     "@folio/stripes": "^7.0.0",
     "moment": "^2.22.2",
     "react": "*",


### PR DESCRIPTION
Changed registry from a hard dependency to a dev dep/peer dep. Peer dep should be sufficient, assuming that the version will be pulled in by the platform/workspace, but since our apps can build standalone and Yarn does not pull in peer deps by default, it has been added as a dev dep as well. Versions will need to be kept aligned with any other Registry dependencies in a build to ensure that multiple Registries aren't being registered to/read from.

ERM-2073