### PR TITLE
chore: Stripes-erm-components

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@folio/eslint-config-stripes": "^6.3.0",
     "@folio/stripes": "^7.3.1",
     "@folio/stripes-cli": "^2.6.1",
-    "@folio/stripes-erm-components": "^7.0.1",
+    "@folio/stripes-erm-components": "^8.0.0",
     "@folio/stripes-erm-testing": "^1.0.0",
     "@folio/stripes-testing": "^4.2.0",
     "@formatjs/cli": "^4.2.31",
@@ -120,6 +120,7 @@
   "peerDependencies": {
     "@folio/handler-stripes-registry": "^1.0.0",
     "@folio/stripes": "^7.0.0",
+    "@folio/stripes-erm-components": "^8.0.0",
     "moment": "^2.22.2",
     "react": "*",
     "react-dom": "*",


### PR DESCRIPTION
Bumped major version of stripes-erm-components to ^8.0.0, reflecting removal of testing stuff for Orchid